### PR TITLE
patched: WP 6.0+ broken queries

### DIFF
--- a/index.php
+++ b/index.php
@@ -82,6 +82,8 @@ class WP_Query_Multisite {
 	}
 
 	function posts_request($sql, $query) {
+		
+		$sql = preg_replace('/\s+/', " ", $sql); 
 
 		if($query->get('multisite')) {
 


### PR DESCRIPTION
WP changed how they format and pass the $sql var to the posts_requests hook (and probably elsewhere too). Added a preg_replace line to remove multiple spaces/tabs and replace with single spaces so the str_replace functions work properly.